### PR TITLE
docs: document secret-rotation opt-out and rotation-required webhook

### DIFF
--- a/enterprise/delegation-credential-microsoft-365.mdx
+++ b/enterprise/delegation-credential-microsoft-365.mdx
@@ -42,13 +42,13 @@ Before starting, make sure you have:
 
 ## Step 2: Add API permissions
 
-The application needs three Microsoft Graph **application permissions** so Cal.com can read and write calendars, resolve users by email, and rotate its own client secret.
+The application needs two Microsoft Graph **application permissions** so Cal.com can read and write calendars and resolve users by email. A third permission, `Application.ReadWrite.OwnedBy`, is only required if you want Cal.com to rotate the client secret automatically before it expires.
 
 | Permission | Why Cal.com needs it |
 | --- | --- |
 | `Calendars.ReadWrite` | Read availability and create or update calendar events for members in the tenant. |
 | `User.Read.All` | Resolve the Microsoft 365 user for a Cal.com member by their email address. |
-| `Application.ReadWrite.OwnedBy` | Automatically rotate the client secret on the app registration Cal.com owns, before it expires. |
+| `Application.ReadWrite.OwnedBy` | Automatically rotate the client secret on the app registration Cal.com owns, before it expires. **Not required** if you [opt out of automatic secret rotation](#client-secret-rotation) and manage rotation manually. |
 
 <Steps>
   <Step title="Open API permissions">
@@ -58,19 +58,19 @@ The application needs three Microsoft Graph **application permissions** so Cal.c
     Choose **Microsoft Graph**, then **Application permissions** (not delegated).
   </Step>
   <Step title="Add the required permissions">
-    Search for and add each of the following, one at a time:
+    Search for and add:
 
     - `Calendars.ReadWrite`
     - `User.Read.All`
-    - `Application.ReadWrite.OwnedBy`
+    - `Application.ReadWrite.OwnedBy` — skip this one if you plan to [opt out of automatic secret rotation](#client-secret-rotation)
   </Step>
   <Step title="Grant admin consent">
-    Back on the API permissions page, click **Grant admin consent for &lt;your tenant&gt;** and confirm. The status column should show a green check mark next to all three permissions.
+    Back on the API permissions page, click **Grant admin consent for &lt;your tenant&gt;** and confirm. The status column should show a green check mark next to each permission you added.
   </Step>
 </Steps>
 
 <Warning>
-  Without admin consent, Cal.com cannot use the application to access calendars. Make sure all three permissions show **Granted** before continuing.
+  Without admin consent, Cal.com cannot use the application to access calendars. Make sure the permissions you added show **Granted** before continuing.
 </Warning>
 
 ---
@@ -138,6 +138,30 @@ Once the Delegation Credential is enabled:
 
 ---
 
+## Client secret rotation
+
+Microsoft Entra client secrets expire, so the credential needs a new secret before that happens. By default, Cal.com handles this automatically.
+
+- **Automatic rotation (default)**: With `Application.ReadWrite.OwnedBy` granted, Cal.com mints a new client secret ahead of expiry and promotes it once it's confirmed to work — no action needed from you.
+- **Manual rotation (opt-out)**: You can opt a credential out of automatic rotation if you'd rather manage secrets yourself, for example to keep full control over your app registration's credentials. This is currently only available through the [Cal.com API v2](https://cal.com/docs) — set `optOutAutoSecretRotation: true` when creating or updating the delegation credential. There is no toggle for this in the Cal.com dashboard yet.
+
+<Note>
+  Automatic secret rotation only applies to Microsoft 365 delegation credentials. Google Workspace delegation credentials use a service account key that doesn't expire, so there's no rotation to opt out of.
+</Note>
+
+### What happens after opting out
+
+Once a credential has opted out of automatic rotation, Cal.com stops minting and promoting secrets for it. Instead, it sends a reminder: about 14 days before the current secret expires, Cal.com fires a `DELEGATION_CREDENTIAL_ROTATION_REQUIRED` [webhook](/webhooks) so you can rotate the secret yourself before the credential stops working.
+
+To act on the reminder:
+
+1. Create a new client secret for the application in the Microsoft Entra admin center (see [Step 3](#step-3-create-a-client-secret) above).
+2. Update the delegation credential in Cal.com with the new secret value, either from **Settings → Organization → Delegation Credential** or via the API.
+
+If you opted out, you don't need to grant `Application.ReadWrite.OwnedBy` — Cal.com never attempts to modify the app registration's secrets for an opted-out credential.
+
+---
+
 ## Disabling the Delegation Credential
 
 Disabling a Delegation Credential:
@@ -160,15 +184,18 @@ If you no longer need the underlying app registration, you can also remove the c
     The Delegation Credential takes priority for the matching domain. The member's manual connection is preserved but the delegation-managed credential is used for calendar operations.
   </Accordion>
   <Accordion title="What permissions does the application get?">
-    The application is granted three Microsoft Graph application permissions:
+    The application is granted up to three Microsoft Graph application permissions:
 
     - **Calendars.ReadWrite** — read availability and create or update calendar events for members in the configured tenant.
     - **User.Read.All** — resolve the Microsoft 365 user for a Cal.com member by their email address.
-    - **Application.ReadWrite.OwnedBy** — rotate the client secret on the app registration Cal.com owns before it expires.
+    - **Application.ReadWrite.OwnedBy** — rotate the client secret on the app registration Cal.com owns before it expires. Only needed if you use [automatic secret rotation](#client-secret-rotation); skip it if you opt out and rotate secrets manually.
 
     Cal.com cannot read mail, files, or any other Microsoft 365 data, and `Application.ReadWrite.OwnedBy` is scoped to applications the credential owns — it cannot modify other apps in your tenant.
   </Accordion>
   <Accordion title="What happens when the client secret expires?">
-    With `Application.ReadWrite.OwnedBy` granted, Cal.com automatically rotates the client secret before it expires — you do not need to create a new secret manually. If the permission is not granted (or admin consent is revoked), the credential stops working once the secret expires. Create a new client secret in the Microsoft Entra admin center and update the credential in Cal.com from the Delegation Credential settings.
+    With `Application.ReadWrite.OwnedBy` granted, Cal.com automatically rotates the client secret before it expires — you do not need to create a new secret manually. If you've [opted out of automatic rotation](#client-secret-rotation), or the permission is not granted (or admin consent is revoked), the credential stops working once the secret expires. Create a new client secret in the Microsoft Entra admin center and update the credential in Cal.com from the Delegation Credential settings.
+  </Accordion>
+  <Accordion title="Can I turn off automatic secret rotation?">
+    Yes. See [Client secret rotation](#client-secret-rotation) above — this is currently only available via the API v2, not the dashboard. Opted-out credentials get a `DELEGATION_CREDENTIAL_ROTATION_REQUIRED` webhook about 14 days before their secret expires, as a reminder to rotate it manually.
   </Accordion>
 </AccordionGroup>

--- a/webhooks.mdx
+++ b/webhooks.mdx
@@ -50,7 +50,7 @@ To create a new webhook subscription, visit `/settings/developer/webhooks` and p
 
     If your subscriber URL does not meet these requirements, the webhook creation request will be rejected with an error.
 
-2. Event triggers: You can decide which triggers specifically to listen to. Currently, we offer listening to `Booking Cancelled`, `Booking Created`, `Booking Rescheduled`, `Booking Rejected`, `Booking Requested`, `Booking Paid`, `Booking Payment Initiated`, `Booking No-Show Updated`, `Meeting Started`, `Meeting Ended`, `Recording Ready`, `Recording Transcription Generated`, `Instant Meeting Created`, `Instant Meeting Accepted`, `Out of Office Created`, `After Hosts Cal Video No-Show`, `After Guests Cal Video No-Show`, `Form Submitted`, `Form Submitted (No Event)`, and `Calendar Entry Rejected`.
+2. Event triggers: You can decide which triggers specifically to listen to. Currently, we offer listening to `Booking Cancelled`, `Booking Created`, `Booking Rescheduled`, `Booking Rejected`, `Booking Requested`, `Booking Paid`, `Booking Payment Initiated`, `Booking No-Show Updated`, `Meeting Started`, `Meeting Ended`, `Recording Ready`, `Recording Transcription Generated`, `Instant Meeting Created`, `Instant Meeting Accepted`, `Out of Office Created`, `After Hosts Cal Video No-Show`, `After Guests Cal Video No-Show`, `Form Submitted`, `Form Submitted (No Event)`, `Calendar Entry Rejected`, and `Delegation Credential Rotation Required`.
 
 3. Secret: You can provide a secret key with this webhook and then [verify it](/docs/core-features/webhooks#verifying-the-authenticity-of-the-received-payload) on the subscriber URL when receiving a payload to confirm if the payload is authentic or adulterated. You can leave it blank, if you don't wish to secure the webhook with a secret key.
 
@@ -80,6 +80,7 @@ To create a new webhook subscription, visit `/settings/developer/webhooks` and p
 | Form Submitted                    | A form is submitted as part of a routing form **with** a scheduled event.                                     |
 | Form Submitted (No Event)         | A form is submitted **without** a scheduled event (form-only flow).                                           |
 | Calendar Entry Rejected           | An external attendee declines a Cal.com event from their connected Google or Microsoft 365 calendar.          |
+| Delegation Credential Rotation Required | The client secret for a Microsoft 365 [Delegation Credential](/enterprise/delegation-credential-microsoft-365) that has opted out of automatic rotation is approaching expiry (~14 days out). Organization-level only. |
 
 
 ### Seated event types


### PR DESCRIPTION
## Summary
- Clarifies that the `Application.ReadWrite.OwnedBy` Microsoft Graph permission is only needed for **automatic** client-secret rotation — credentials that opt out of it don't need to grant it (ENG-2103).
- Adds a **Client secret rotation** section to the Microsoft 365 Delegation Credential article covering the `optOutAutoSecretRotation` setting (API v2-only, no dashboard toggle yet) and what happens after opting out — a manual-rotation reminder instead of automatic rotation (ENG-2449).
- References the `DELEGATION_CREDENTIAL_ROTATION_REQUIRED` webhook trigger (fires ~14 days before secret expiry, org-level, opted-out credentials only) in the public webhooks article's trigger table.
- Google Workspace isn't touched — it uses non-expiring service account keys, so this rotation lifecycle is Microsoft 365-specific.

Verified all technical details (field name, API endpoints, ~14-day threshold, webhook scope) against the calcom/cal implementation before writing.

## Test plan
- [ ] Preview the Microsoft 365 delegation credential article and confirm the new "Client secret rotation" section renders correctly and in-page anchors (`#client-secret-rotation`, `#step-3-create-a-client-secret`) resolve.
- [ ] Preview the webhooks article and confirm the new trigger table row renders correctly.

Refs ENG-2449, ENG-2103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRVbHRvojp8ANyWNjdyK7o